### PR TITLE
:bug: fix request and exit

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,7 +73,7 @@ def scraping(client):
         t = time.time()
         invalidset = set()
         html = json.loads(h.text)
-        if "submissions_dump" not in html:
+        if not html.get("submissions_dump") :
             print ("Warning! No previous submission is detected, please make sure you are logging in the correct account AND you once submitted codes on leetcode-cn.com")
             break
             
@@ -126,7 +126,7 @@ def scraping(client):
                 
             except Exception as e:
                 print(e)
-            
+        time.sleep(1)
         page_num += 20
 
 def git_push():


### PR DESCRIPTION
request 间隔sleep 1  否则会得到 你没有权限执行的返回body，但是程序json.load会以为没有submissions_dump，从而提前退出。实际上是请求过于频繁

翻页超出内容的时候 html key中仍然包含submissions_dump，所以要通过内容判断：如下。
Now for page: 620
{'submissions_dump': [], 'has_next': False, 'last_key': ''}
Now for page: 640
{'submissions_dump': [], 'has_next': False, 'last_key': ''}
Now for page: 660
{'submissions_dump': [], 'has_next': False, 'last_key': ''}